### PR TITLE
timezone is not supported in digital signs

### DIFF
--- a/sign/src/main/java/com/itextpdf/signatures/SignUtils.java
+++ b/sign/src/main/java/com/itextpdf/signatures/SignUtils.java
@@ -270,7 +270,9 @@ final class SignUtils {
     }
 
     public static String dateToString(Calendar signDate) {
-        return new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z").format(signDate.getTime());
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd HH:mm:ss z");
+        if(signDate.getTimeZone() != null) sdf.setTimeZone(signDate.getTimeZone());
+        return sdf.format(signDate.getTime());
     }
 
     static class TsaResponse {


### PR DESCRIPTION
timezone is not supported in digital signs. which is fixed here and the timezone is being fetched from the passed calendar instance.